### PR TITLE
Bump to 1.5.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "threatstack-threatstack",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Threat Stack",
   "license": "Apache-2.0",
   "summary": "Installs the Threat Stack agent",


### PR DESCRIPTION
- Fix RHEL 6 and Amazon curl/TLS issue fetching repo GPG key
