### PR TITLE
Checking to see if wget is defined elsewhere

### DIFF
--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -24,7 +24,9 @@ class threatstack::yum {
   # Our site only supports TLS > 1.0 which curl, used by yum, does not support
   # in RHEL 6.  We use wget because even better, the --tlsv1 flag to curl does
   # not work before 6.7.
-  ensure_resource( 'package', 'wget', { 'ensure' => 'installed' } )
+  if (!defined(Package['wget'])) {
+    ensure_resource( 'package', 'wget', { 'ensure' => 'installed' } )
+  }
 
   exec { 'ts-gpg-fetch':
     command => "wget ${::threatstack::gpg_key} -O ${::threatstack::gpg_key_file}",


### PR DESCRIPTION
Adding this check to make sure that wget isn't defined elsewhere outsite
this module.  For example in our control repo we use the wget module,
which is causing a conflict with this resource