### PR TITLE
Curl defined multiple times fix

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -23,7 +23,7 @@ class threatstack::apt {
     path => ['/bin', '/usr/bin']
   }
 
-  ensure_resource( 'package','curl', { 'ensure' => 'installed' } )
+  ensure_packages('curl')
 
   file { $apt_source_file:
     owner   => 'root',

--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -23,7 +23,12 @@ class threatstack::apt {
     path => ['/bin', '/usr/bin']
   }
 
-  ensure_packages('curl')
+  # Handle setups where curl is defined but with different attributes. This
+  # should be fixed sometime in 4.15.x or 4.16.x of stdlib.  Fix is in master
+  # but not released.
+  if !defined(Package['curl']) {
+    ensure_packages('curl')
+  }
 
   file { $apt_source_file:
     owner   => 'root',


### PR DESCRIPTION
If ensure_resource( 'package','curl', { 'ensure' => 'installed' } ) is used, it produces errors when used with some other puppet modules that also defile curl.

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Package[curl] is already declared; cannot redeclare at /etc/puppet/environments/user/modules/threatstack/manifests/apt.pp:26 on node

That error is not produced with the fix.