### PR TITLE
use operatingsystem fact instead of osfamily here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .bundle
 .kitchen.local.yml
 .librarian/
+.ruby-version
 .tmp/
 modules/
 pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ sudo: required
 rvm:
 - 2.1.0
 env:
-- PUPPET_VERSION="~> 3.6.0"
-- PUPPET_VERSION="~> 3.7.0"
 - PUPPET_VERSION="~> 3.8.0"
 - PUPPET_VERSION="~> 4.6.0"
 - PUPPET_VERSION="~> 4.7.0"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development, :unit_tests do
   gem 'metadata-json-lint', '0.0.4', :require => false
   gem 'vagrant-wrapper',             :require => false
   gem 'puppet-blacksmith',           :require => false
-  gem 'rest-client', "1.7.3",        :require => false
+  gem 'rest-client', ">=1.7.3",      :require => false
 end
 group :system_tests do
   gem 'serverspec',      :require => false

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class { '::threatstack':
 
 Agent installation into golden image
 ===
-If installing the agent into an image that will be deployed for multiple insatnces, configure the class to not configure the agent while creating the image.  If the agent is registered and configured in the golden image then events and alerting will not be correct.
+If installing the agent into an image that will be deployed for multiple instances, configure the class to not configure the agent while creating the image.  If the agent is registered and configured in the golden image then events and alerting will not be correct.
 ```
 class { '::threatstack':
   configure_agent => false,

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,6 @@ desc 'Run syntax, lint, and spec tests.'
 task :test => [
   :syntax,
   :lint,
-  :metadata,
+  :metadata_lint,
   :spec,
 ]

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -19,7 +19,7 @@
 class threatstack::configure {
 
   $rulesets     = $::threatstack::ruleset # bring value into scope.
-  $ruleset_args = inline_template("<% @rulesets.each do |ruleset| -%> --ruleset=\"<%= ruleset %>\"<% end -%>")
+  $ruleset_args = inline_template("<% @rulesets.each do |ruleset| -%> --ruleset='<%= ruleset %>'<% end -%>")
 
   $feature_plan_arg = $::threatstack::feature_plan ? {
     investigate => 'agent_type="i"',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,22 +23,17 @@ class threatstack::params {
   $ruleset    = ['Base Rule Set']
 
   case $::osfamily {
-    'RedHat', 'Amazon', 'Fedora': {
+    'RedHat': {
       $repo_class       = '::threatstack::yum'
       $gpg_key          = 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file     = '/etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file_uri = "file://${gpg_key_file}"
 
-      if $::osfamily == 'Amazon' {
-        $repo_url = 'https://pkg.threatstack.com/Amazon'
+      case $::operatingsystem {
+        'Amazon': { $repo_url = 'https://pkg.threatstack.com/Amazon'}
+        /(CentOS|RedHat)/: { $repo_url = "https://pkg.threatstack.com/EL/${::operatingsystemmajrelease}" }
+        default: { fail("Module ${module_name} does not support ${::operatingsystem}") }
       }
-      elsif $::osfamily == 'Fedora' {
-        $repo_url = 'https://pkg.threatstack.com/El/7'
-      }
-      else {
-        $repo_url = "https://pkg.threatstack.com/EL/${::operatingsystemmajrelease}"
-      }
-
     }
     'Debian': {
       $repo_class = '::threatstack::apt'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "threatstack-threatstack",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "Threat Stack",
   "license": "Apache-2.0",
   "summary": "Installs the Threat Stack agent",
@@ -13,11 +13,14 @@
   "operatingsystem_support": [
     {
     "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "6.0", "6.5", "7.0" ]
+    "operatingsystemrelease":[ "6.0", "6.5", "7.0", "7.5" ]
     },
     {
     "operatingsystem":"CentOS",
-    "operatingsystemrelease":[ "6.0", "6.5", "7.0" ]
+    "operatingsystemrelease":[ "6.0", "6.5", "7.0", "7.5" ]
+    },
+    {
+    "operatingsystem":"Amazon"
     },
     {
     "operatingsystem": "Ubuntu",

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
     },
     {
     "operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [ "16.04", "14.04", "12.04", "10.04" ]
+    "operatingsystemrelease": [ "16.04", "14.04" ]
     }
    ]
 }

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -9,36 +9,12 @@ describe 'threatstack::apt' do
     let(:facts) { {:osfamily => 'Debian'} }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
 
-    it { should contain_package('curl').with_ensure('installed') }
+    it { should contain_package('curl').with_ensure('present') }
     it { should contain_exec('ts-agent-apt-get-update').with(
       :command => 'apt-get update'
     )}
     it { should contain_exec('ts-gpg-import').with(
       :command => 'curl https://app.threatstack.com/APT-GPG-KEY-THREATSTACK | apt-key add -'
-    )}
-  end
-
-  context 'on Ubuntu Lucid 10.04' do
-    let(:facts) { {:osfamily => 'Debian', :lsbdistcodename => 'lucid' } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
-
-    it { should contain_file('/etc/apt/sources.list.d/threatstack.list').with(
-      :owner => 'root',
-      :group => 'root',
-      :mode  => '0644',
-      :content => 'deb https://pkg.threatstack.com/Ubuntu lucid main'
-    )}
-  end
-
-  context 'on Ubuntu Precise 12.04' do
-    let(:facts) { {:osfamily => 'Debian', :lsbdistcodename => 'precise' } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
-
-    it { should contain_file('/etc/apt/sources.list.d/threatstack.list').with(
-      :owner => 'root',
-      :group => 'root',
-      :mode  => '0644',
-      :content => 'deb https://pkg.threatstack.com/Ubuntu precise main'
     )}
   end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,7 +16,17 @@ describe 'threatstack' do
   end
 
   context 'on RedHat' do
-    let(:facts) { {:osfamily => 'RedHat'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
+    let(:params) { { :deploy_key => "#{deploy_key}", :feature_plan => "#{feature_plan}" } }
+
+    it 'should compile' do should create_class('threatstack') end
+    it { should contain_class('threatstack::package') }
+    it { should contain_class('threatstack::configure') }
+
+  end
+
+  context 'on CentOS' do
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'CentOS'} }
     let(:params) { { :deploy_key => "#{deploy_key}", :feature_plan => "#{feature_plan}" } }
 
     it 'should compile' do should create_class('threatstack') end
@@ -26,7 +36,7 @@ describe 'threatstack' do
   end
 
   context 'on Amazon' do
-    let(:facts) { {:osfamily => 'Amazon'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon'} }
     let(:params) { { :deploy_key => "#{deploy_key}", :feature_plan => "#{feature_plan}" } }
 
     it 'should compile' do should create_class('threatstack') end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -6,7 +6,7 @@ describe 'threatstack::package' do
   feature_plan = ENV['TS_FEATURE_PLAN'] ? ENV['TS_FEATURE_PLAN'] : "monitor"
 
   context 'on RedHat' do
-    let(:facts) { {:osfamily => 'RedHat'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'RedHat'} }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
 
     context 'package' do

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -36,7 +36,7 @@ describe 'threatstack::yum' do
   end
 
   context 'on Amazon' do
-    let(:facts) { {:osfamily => 'Amazon'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'Amazon'} }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
 
     context 'default' do

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -6,7 +6,7 @@ describe 'threatstack::yum' do
   feature_plan = ENV['TS_FEATURE_PLAN'] ? ENV['TS_FEATURE_PLAN'] : "monitor"
 
   context 'on RedHat' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => '6'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => '6', :operatingsystem => 'RedHat'} }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
 
     context 'default' do
@@ -21,7 +21,7 @@ describe 'threatstack::yum' do
   end
 
   context 'on CentOS' do
-    let(:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => '7'} }
+    let(:facts) { {:osfamily => 'RedHat', :operatingsystemmajrelease => '7', :operatingsystem => 'CentOS'} }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', feature_plan => '#{feature_plan}' }" }
 
     context 'default' do


### PR DESCRIPTION
amazon linux is in the redhat family, so set the repo via `operatingsystem` fact instead. as it is now, this causes errors on amazon linux hosts. also remove fedora, as it's not in the support matrix any more.