### PR TITLE
Auditd fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 We'll track changes here starting with details about the 2.0 release and reference to earlier releases.
 
+## 2.0.1
+### Changed
+- added optional parameter `disable_auditd` to handle issues users reported installing on RHEL-like OSes
+
+### Fixed
+- fixed amazon linux 2 yum repo assignment
+
 ## 2.0
 ### This release tracks the release of the Threat Stack Agent 2.0
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For more see https://www.threatstack.com.
 Platforms
 ---------
 
-* Amazon Linux
+* Amazon Linux 2
 * CentOS
 * Debian
 * RedHat
@@ -40,6 +40,7 @@ Parameters
 * `threatstack::rulesets` [optional array] - Set the ruleset or rulesets the node will be added to (Default: 'Base Rule Set').
 * `threatstack::configure_agent` [optiona bool] - Set to false to just install agent without configuring. Useful for image building.
 * `threatstack::agent_config_args` [optional array of hashes] - Extra arguments to pass during agent activation. Useful for enabling new platform features.
+* `threatstack::disable_auditd` [optional bool] - Disable `auditd` service to avoid installation issues. (Default is 'true' on RHEL-like OSes.)
 * `threatstack::extra_args` [optional array of hashes] - optional array of hashes to define setup options for the threatstack agent (Default: `undef`)
 * `threatstack::confdir` [optional string] - path to config directory for the threatstack service (Default: '/opt/threatstack/etc')
 * `threatstack::ts_hostname` [optional string] - hostname of your node (Default: `$::fqdn`)

--- a/data/os/Amazon.yaml
+++ b/data/os/Amazon.yaml
@@ -2,3 +2,4 @@
 threatstack::params:
     repo_class: '::threatstack::yum'
     gpg_key: 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
+    disable_auditd: true

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -2,3 +2,4 @@
 threatstack::params:
     repo_class: '::threatstack::yum'
     gpg_key: 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
+    disable_auditd: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,10 @@
 #   Arguments to be passed to `tsagent setup`
 #   type: array
 #
+# [*disable_auditd*]
+#   Required to work around issues with auditd on some distros
+#   type: bool
+#
 # [*extra_args*]
 #   Extra arguments to pass on the command line during agent activation.
 #   type: array of hashes
@@ -86,7 +90,8 @@ class threatstack (
   $gpg_key           = $::threatstack::params::gpg_key,
   $rulesets          = $::threatstack::params::rulesets,
   $confdir           = $::threatstack::params::confdir,
-  $ts_hostname       = $::fqdn
+  $ts_hostname       = $::fqdn,
+  $disable_auditd    = $::threatstack::params::disable_auditd
 ) inherits ::threatstack::params {
 
   $ts_package = $::threatstack::params::ts_package

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -20,12 +20,22 @@ class threatstack::package {
 
   class { $::threatstack::repo_class: }
 
+  if $::threatstack::disable_auditd {
+    service { 'auditd':
+      ensure => 'stopped',
+      enable => false
+    }
+  $required = [ Class[$::threatstack::repo_class], Service['auditd'] ]
+  } else {
+    $required = Class[$::threatstack::repo_class]
+  }
+
   # NOTE: We do not signal the tsagent service to restart because the
   # package takes care of this.  The workflow differs between fresh
   # installation and upgrades.
   package { $::threatstack::ts_package:
     ensure  => $::threatstack::package_version,
-    require => Class[$::threatstack::repo_class]
+    require => $required
   }
 
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -21,11 +21,17 @@ class threatstack::package {
   class { $::threatstack::repo_class: }
 
   if $::threatstack::disable_auditd {
-    service { 'auditd':
-      ensure => 'stopped',
-      enable => false
+    exec { 'stop_auditd':
+      command => '/sbin/service auditd stop',
+      onlyif  => '/sbin/service auditd status'
     }
-  $required = [ Class[$::threatstack::repo_class], Service['auditd'] ]
+
+    exec { 'disable_auditd':
+      command => '/bin/systemctl disable auditd',
+      require => Exec['stop_auditd']
+    }
+
+  $required = [ Class[$::threatstack::repo_class], Exec['stop_auditd'] ]
   } else {
     $required = Class[$::threatstack::repo_class]
   }
@@ -37,5 +43,4 @@ class threatstack::package {
     ensure  => $::threatstack::package_version,
     require => $required
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class threatstack::params {
   $extra_args      = undef
   $cloudsight_bin  = '/usr/bin/tsagent'
   $confdir         = '/opt/threatstack/etc'
+  $disable_auditd  = false
 
   case $facts['os']['family'] {
     'RedHat': {
@@ -34,7 +35,10 @@ class threatstack::params {
       $gpg_key_file_uri = "file://${gpg_key_file}"
 
       case $facts['os']['name'] {
-        'Amazon': { $repo_url = 'https://pkg.threatstack.com/v2/Amazon'}
+        'Amazon': {
+              $repo_url       = 'https://pkg.threatstack.com/v2/Amazon'
+              $disable_auditd = true
+            }
         /(CentOS|RedHat)/: { $repo_url = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}" }
         default: { fail("Module ${module_name} does not support ${::operatingsystem}") }
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,11 +32,11 @@ class threatstack::params {
       $gpg_key          = 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file     = '/etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file_uri = "file://${gpg_key_file}"
+      $disable_auditd   = true
 
       case $facts['os']['name'] {
         'Amazon': {
               $repo_url       = "https://pkg.threatstack.com/v2/Amazon/${::operatingsystemmajrelease}"
-              $disable_auditd = true
             }
         /(CentOS|RedHat)/: {
               $repo_url         = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,6 @@ class threatstack::params {
   $extra_args      = undef
   $cloudsight_bin  = '/usr/bin/tsagent'
   $confdir         = '/opt/threatstack/etc'
-  $disable_auditd  = false
 
   case $facts['os']['family'] {
     'RedHat': {
@@ -33,6 +32,7 @@ class threatstack::params {
       $gpg_key          = 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file     = '/etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file_uri = "file://${gpg_key_file}"
+      $disable_auditd   = false
 
       case $facts['os']['name'] {
         'Amazon': {
@@ -44,12 +44,13 @@ class threatstack::params {
       }
     }
     'Debian': {
-      $repo_class   = '::threatstack::apt'
-      $repo_url     = 'https://pkg.threatstack.com/v2/Ubuntu'
-      $repo_gpg_id  = 'ACCC2B02EA3A2409557B0AB991BB3B3C6EE04BD4'
-      $release      = $facts['os']['distro']['codename']
-      $repos        = 'main'
-      $gpg_key      = 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
+      $repo_class     = '::threatstack::apt'
+      $repo_url       = 'https://pkg.threatstack.com/v2/Ubuntu'
+      $repo_gpg_id    = 'ACCC2B02EA3A2409557B0AB991BB3B3C6EE04BD4'
+      $release        = $facts['os']['distro']['codename']
+      $repos          = 'main'
+      $gpg_key        = 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
+      $disable_auditd = false
     }
     default: {
       fail("Module ${module_name} does not support ${::operatingsystem}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,14 +32,16 @@ class threatstack::params {
       $gpg_key          = 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file     = '/etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file_uri = "file://${gpg_key_file}"
-      $disable_auditd   = false
 
       case $facts['os']['name'] {
         'Amazon': {
               $repo_url       = 'https://pkg.threatstack.com/v2/Amazon'
               $disable_auditd = true
             }
-        /(CentOS|RedHat)/: { $repo_url = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}" }
+        /(CentOS|RedHat)/: {
+              $repo_url         = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}"
+              $disable_auditd   = false
+            }
         default: { fail("Module ${module_name} does not support ${::operatingsystem}") }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,6 @@ class threatstack::params {
             }
         /(CentOS|RedHat)/: {
               $repo_url         = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}"
-              $disable_auditd   = false
             }
         default: { fail("Module ${module_name} does not support ${::operatingsystem}") }
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class threatstack::params {
 
       case $facts['os']['name'] {
         'Amazon': {
-              $repo_url       = 'https://pkg.threatstack.com/v2/Amazon'
+              $repo_url       = "https://pkg.threatstack.com/v2/Amazon/${facts['os']['release']['major']}"
               $disable_auditd = true
             }
         /(CentOS|RedHat)/: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class threatstack::params {
 
       case $facts['os']['name'] {
         'Amazon': {
-              $repo_url       = "https://pkg.threatstack.com/v2/Amazon/${facts['os']['release']['major']}"
+              $repo_url       = "https://pkg.threatstack.com/v2/Amazon/${::operatingsystemmajrelease}"
               $disable_auditd = true
             }
         /(CentOS|RedHat)/: {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "threatstack-threatstack",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Threat Stack",
   "license": "Apache-2.0",
   "summary": "Installs the Threat Stack agent",

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -60,7 +60,7 @@ describe 'threatstack::configure' do
   end
 
   context 'on Amazon Linux' do
-    let(:facts) {  {'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
+    let(:facts) {  {'operatingsystemmajrelease' => '2', 'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,7 +61,7 @@ describe 'threatstack' do
   end
 
   context 'on Amazon' do
-    let(:facts) {  {'operatingsystemmajrelease' => '2', 'os' => { 'name' => 'Amazon', 'family' => 'RedHat'} } }
+    let(:facts) { { 'operatingsystemmajrelease' => '2', 'os' => { 'name' => 'Amazon', 'family' => 'RedHat'} } }
     let(:params) { { :deploy_key => "#{deploy_key}" } }
 
     it 'should compile' do should create_class('threatstack') end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,7 +61,7 @@ describe 'threatstack' do
   end
 
   context 'on Amazon' do
-    let(:facts) {  {'os' => { 'name' => 'Amazon', 'family' => 'RedHat'} } }
+    let(:facts) {  {'operatingsystemmajrelease' => '2', 'os' => { 'name' => 'Amazon', 'family' => 'RedHat'} } }
     let(:params) { { :deploy_key => "#{deploy_key}" } }
 
     it 'should compile' do should create_class('threatstack') end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -22,7 +22,7 @@ describe 'threatstack::package' do
   end
 
   context 'on Amazon Linux' do
-    let(:facts) {  {'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
+    let(:facts) {  {'operatingsystemmajrelease' => '2', 'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
 
     context 'package' do

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -43,7 +43,7 @@ describe 'threatstack::yum' do
       it { should contain_yumrepo('threatstack').with(
         :descr     => 'Threat Stack Package Repository',
         :enabled   => 1,
-        :baseurl   => 'https://pkg.threatstack.com/v2/Amazon',
+        :baseurl   => 'https://pkg.threatstack.com/v2/Amazon/2',
         :gpgcheck  => 1,
         :gpgkey    => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       ) }

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -36,7 +36,7 @@ describe 'threatstack::yum' do
   end
 
   context 'on Amazon' do
-    let(:facts) {  {'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
+    let(:facts) {  {'operatingsystemmajrelease' => '2', 'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
 
     context 'default' do


### PR DESCRIPTION
this should optionally disable the `auditd` service before installing threatstack agent to avoid issues. default is `true` on all supported rhel like distros, where the issue was identified. you can override this based on your needs by passing `threatstack::disable_auditd = false`.