### PR TITLE
Manage auditd using service instead of exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Parameters
 * `threatstack::configure_agent` [optiona bool] - Set to false to just install agent without configuring. Useful for image building.
 * `threatstack::agent_config_args` [optional array of hashes] - Extra arguments to pass during agent activation. Useful for enabling new platform features.
 * `threatstack::disable_auditd` [optional bool] - Disable `auditd` service to avoid installation issues. (Default is 'true' on RHEL-like OSes.)
-* `threatstack::disable_auditd_cmd` [optional string] - related to `threatstack::disable_auditd`, the OS version dependent command to disable auditd (Default: set in `threatstack::params` based on operating system)
+* `threatstack::disable_auditd_provider` [optional string] - related to `threatstack::disable_auditd`, the Puppet service provider to disable auditd (Default: set in `threatstack::params` based on operating system)
 * `threatstack::extra_args` [optional array of hashes] - optional array of hashes to define setup options for the threatstack agent (Default: `undef`)
 * `threatstack::confdir` [optional string] - path to config directory for the threatstack service (Default: '/opt/threatstack/etc')
 * `threatstack::ts_hostname` [optional string] - hostname of your node (Default: `$::fqdn`)
@@ -63,7 +63,7 @@ Supply your Threat Stack deploy key, and if you choose, an array of rulesets.
 ```
 class { '::threatstack':
   deploy_key    => 'MyDeployKey',
-  ruleset       => ['MyRuleset']
+  rulesets      => ['MyRuleset']
 }
 ```
 Using a package mirror
@@ -72,7 +72,7 @@ If you manage your own package repository from which you deploy the agent packag
 ```
 class { '::threatstack':
   deploy_key    => 'MyDeployKey',
-  ruleset       => ['MyRuleset'],
+  rulesets      => ['MyRuleset'],
   repo_url      => 'https://my-mirror.example.com/centos-6'
   gpg_key       => 'https://my-mirror.example.com/RPM-GPG-KEY-THREATSTACK'
 }

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -62,7 +62,7 @@ class threatstack::configure {
   }
   case $facts['os']['family'] {
     'Windows': {
-      notice("Windows agent setup should be done at install time.")
+      notice('Windows agent setup should be done at install time.')
     }
     default: {
       exec { 'threatstack-agent-setup':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,8 +16,8 @@
 #   Required to work around issues with auditd on some distros
 #   type: bool
 #
-# [*disable_auditd_cmd*]
-#   Systemd vs. SysV init, related to above
+# [*disable_auditd_provider*]
+#   Puppet service provider used to disable auditd
 #   type: string
 #
 # [*enable_sysmon*]
@@ -125,7 +125,7 @@ class threatstack (
   $confdir                 = $::threatstack::params::confdir,
   $ts_hostname             = $::fqdn,
   $disable_auditd          = $::threatstack::params::disable_auditd,
-  $disable_auditd_cmd      = $::threatstack::params::disable_auditd_cmd,
+  $disable_auditd_provider = $::threatstack::params::disable_auditd_provider,
   $binpath                 = $::threatstack::params::binpath,
   $setup_unless            = $::threatstack::params::setup_unless,
   $windows_download_url    = $::threatstack::params::download_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,19 +55,19 @@ class threatstack::params {
 
   $package_version = 'installed'
   $extra_args      = undef
-  $windows_install_options = ["TSEVENTLOGLIST=Security,Microsoft-Windows-Sysmon/Operational"]
+  $windows_install_options = ['TSEVENTLOGLIST=Security,Microsoft-Windows-Sysmon/Operational']
 
   case $facts['os']['family'] {
     'Windows': {
-      $repo_class         = '::threatstack::msi'
-      $repo_url           = undef
-      $gpg_key            = undef
-      $disable_auditd     = false
-      $disable_auditd_cmd = undef
-      $windows_base_url   = "https://pkg.threatstack.com/v2/Windows"
-      $windows_pkg_name   = 'Threat+Stack+Cloud+Security+Agent.latest.msi'
-      $download_url       = "${windows_base_url}/${windows_pkg_name}"
-      $tmp_path           = "C:\\Windows\\Temp\\${windows_pkg_name}"
+      $repo_class              = '::threatstack::msi'
+      $repo_url                = undef
+      $gpg_key                 = undef
+      $disable_auditd          = false
+      $disable_auditd_provider = undef
+      $windows_base_url        = 'https://pkg.threatstack.com/v2/Windows'
+      $windows_pkg_name        = 'Threat+Stack+Cloud+Security+Agent.latest.msi'
+      $download_url            = "${windows_base_url}/${windows_pkg_name}"
+      $tmp_path                = "C:\\Windows\\Temp\\${windows_pkg_name}"
     }
     'RedHat': {
       $repo_class       = '::threatstack::yum'
@@ -79,30 +79,30 @@ class threatstack::params {
       case $facts['os']['name'] {
         'Amazon': {
           if $facts['os']['release']['major'] =~ /^201\d$/ {
-            $releasever         = '1'
-            $disable_auditd_cmd = '/sbin/chkconfig auditd off'
+            $releasever              = '1'
+            $disable_auditd_provider = undef
           } else {
-            $releasever         = $facts['os']['release']['major']
-            $disable_auditd_cmd = '/bin/systemctl disable auditd'
+            $releasever              = $facts['os']['release']['major']
+            $disable_auditd_provider = 'redhat'
           }
-            $repo_url = "https://pkg.threatstack.com/v2/Amazon/${releasever}"
+          $repo_url = "https://pkg.threatstack.com/v2/Amazon/${releasever}"
         }
         /(CentOS|RedHat)/: {
-              $repo_url           = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}"
-              $disable_auditd_cmd = '/bin/systemctl disable auditd'
+          $repo_url                = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}"
+          $disable_auditd_provider = 'redhat' #auditd can't be disabled using systemd: https://access.redhat.com/solutions/2664811
         }
         default: { fail("Module ${module_name} does not support ${::operatingsystem}") }
       }
     }
     'Debian': {
-      $repo_class         = '::threatstack::apt'
-      $repo_url           = 'https://pkg.threatstack.com/v2/Ubuntu'
-      $repo_gpg_id        = 'ACCC2B02EA3A2409557B0AB991BB3B3C6EE04BD4'
-      $release            = $facts['os']['distro']['codename']
-      $repos              = 'main'
-      $gpg_key            = 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
-      $disable_auditd     = false
-      $disable_auditd_cmd = '/bin/systemctl disable auditd'
+      $repo_class              = '::threatstack::apt'
+      $repo_url                = 'https://pkg.threatstack.com/v2/Ubuntu'
+      $repo_gpg_id             = 'ACCC2B02EA3A2409557B0AB991BB3B3C6EE04BD4'
+      $release                 = $facts['os']['distro']['codename']
+      $repos                   = 'main'
+      $gpg_key                 = 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
+      $disable_auditd          = false
+      $disable_auditd_provider = undef
     }
     default: {
       fail("Module ${module_name} does not support ${::operatingsystem}")


### PR DESCRIPTION
We were running into the following issue on Amazon Linux 2 systems if Puppet was being invoked via cron:
`/Stage[main]/Threatstack::Package/Exec[stop_auditd]	Could not evaluate: invalid byte sequence in US-ASCII`

Looking at the way auditd was managed was very inefficient on RedHat based systems - the execs would be executed on every single Puppet run. This seemed like a clear case to use the Puppet service provider.

There is a small caveat on RedHat 7+ systems - systemd can't be used to start/stop auditd. Details are available here:
https://access.redhat.com/solutions/2664811