### PR TITLE
Added service_provider parameter with a default for Amazon Linux

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,6 +70,10 @@
 #   Hostname as reported to Threat Stack.
 #   type: string
 #
+# [*service_provider*]
+#   The Puppet Service provider used to manage the service. Defaults to undef on most distros
+#   type: string
+#
 # [*windows_download_url*]
 #   Windows MSI download url
 #   type: string
@@ -124,6 +128,7 @@ class threatstack (
   $binpath                 = $::threatstack::params::binpath,
   $setup_unless            = $::threatstack::params::setup_unless,
   $enable_sysmon           = $::threatstack::params::enable_sysmon,
+  $service_provider        = $::threatstack::params::service_provider,
   $windows_download_url    = $::threatstack::params::download_url,
   $windows_tmp_path        = $::threatstack::params::tmp_path,
   $windows_install_options = concat(["TSDEPLOYKEY=${deploy_key}"],$::threatstack::params::windows_install_options)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,6 @@ class threatstack::params {
 
   $package_version  = 'installed'
   $extra_args       = undef
-  $service_provider = undef
   $windows_install_options = ['TSEVENTLOGLIST=Security,Microsoft-Windows-Sysmon/Operational']
 
   case $facts['os']['family'] {
@@ -44,6 +43,7 @@ class threatstack::params {
       $setup_unless       = 'tasklist.exe /fi "Imagename eq tsagent*"'
       $binpath            = ["C:\\Program Files\\Threat Stack\\"]
       $cloudsight_bin     = "C:\\Program Files\\Threat Stack\\tsagent.exe"
+      $service_provider   = undef
       $ts_service         = 'Threat Stack Agent'
       $ts_package         = 'Threat Stack Cloud Security Platform'
     }
@@ -71,11 +71,13 @@ class threatstack::params {
             $service_provider   = 'upstart'
           } else {
             $releasever         = $facts['os']['release']['major']
+            $service_provider   = undef
           }
             $repo_url = "https://pkg.threatstack.com/v2/Amazon/${releasever}"
         }
         /(CentOS|RedHat)/: {
               $repo_url           = "https://pkg.threatstack.com/v2/EL/${::operatingsystemmajrelease}"
+              $service_provider   = undef
         }
         default: { fail("Module ${module_name} does not support ${::operatingsystem}") }
       }
@@ -96,6 +98,7 @@ class threatstack::params {
       $setup_unless       = 'ps auwwwx| grep [t]sagentd'
       $binpath            = ['/bin', '/usr/bin']
       $cloudsight_bin     = '/usr/bin/tsagent'
+      $service_provider   = undef
       $ts_service         = 'threatstack'
       $ts_package         = 'threatstack-agent'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,9 @@ class threatstack::params {
 
 
 
-  $package_version = 'installed'
-  $extra_args      = undef
+  $package_version  = 'installed'
+  $extra_args       = undef
+  $service_provider = undef
   $windows_install_options = ['TSEVENTLOGLIST=Security,Microsoft-Windows-Sysmon/Operational']
 
   case $facts['os']['family'] {
@@ -67,6 +68,7 @@ class threatstack::params {
         'Amazon': {
           if $facts['os']['release']['major'] =~ /^201\d$/ {
             $releasever         = '1'
+            $service_provider   = 'upstart'
           } else {
             $releasever         = $facts['os']['release']['major']
           }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,8 @@ class threatstack::params {
 
 
 
-  $package_version  = 'installed'
-  $extra_args       = undef
+  $package_version = 'installed'
+  $extra_args      = undef
   $windows_install_options = ['TSEVENTLOGLIST=Security,Microsoft-Windows-Sysmon/Operational']
 
   case $facts['os']['family'] {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,10 +16,11 @@ class threatstack::service {
   # NOTE: We do not signal the tsagent service to restart via the package
   # resource because the workflow differs between fresh installation and
   # upgrades.  The package scripts will handle this.
-  service { $::threatstack::ts_service:
+  service { 'threatstack':
     ensure     => running,
     enable     => true,
-    hasrestart => true
+    hasrestart => true,
+    provider   => $::threatstack::service_provider
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,7 +16,7 @@ class threatstack::service {
   # NOTE: We do not signal the tsagent service to restart via the package
   # resource because the workflow differs between fresh installation and
   # upgrades.  The package scripts will handle this.
-  service { $::threatstack::params::ts_service:
+  service { $::threatstack::ts_service:
     ensure     => running,
     enable     => true,
     hasrestart => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,7 +16,7 @@ class threatstack::service {
   # NOTE: We do not signal the tsagent service to restart via the package
   # resource because the workflow differs between fresh installation and
   # upgrades.  The package scripts will handle this.
-  service { 'threatstack':
+  service { $::threatstack::params::ts_service:
     ensure     => running,
     enable     => true,
     hasrestart => true,

--- a/manifests/sysmon.pp
+++ b/manifests/sysmon.pp
@@ -20,10 +20,9 @@ class threatstack::sysmon {
     source       => 'https://download.sysinternals.com/files/Sysmon.zip'
   }
 
-  file { 'C:\Windows\Temp\sysmonconfig-export.xml':
+  remote_file { 'C:\Windows\Temp\sysmonconfig-export.xml':
     ensure         => present,
     source         => 'https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml',
-    checksum_value => 'b03fab566310ff214c9285131a0d148f',
     require        => Exec['test conf present']
   }
 

--- a/manifests/sysmon.pp
+++ b/manifests/sysmon.pp
@@ -33,12 +33,12 @@ class threatstack::sysmon {
 
   exec { 'Install sysmon':
     command     => 'C:\Windows\Temp\Sysmon64.exe -accepteula -i C:\Windows\Temp\sysmonconfig-export.xml',
-    subscribe   => File['C:\Windows\Temp\sysmonconfig-export.xml'],
+    subscribe   => Remote_File['C:\Windows\Temp\sysmonconfig-export.xml'],
     refreshonly => true,
     unless      => 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe Get-Process "sysmon64"',
     require     => [
       Archive['C:\Windows\Temp\sysmon.zip'],
-      File['C:\Windows\Temp\sysmonconfig-export.xml']
+      Remote_File['C:\Windows\Temp\sysmonconfig-export.xml']
     ]
   }
 }

--- a/manifests/sysmon.pp
+++ b/manifests/sysmon.pp
@@ -21,9 +21,9 @@ class threatstack::sysmon {
   }
 
   remote_file { 'C:\Windows\Temp\sysmonconfig-export.xml':
-    ensure         => present,
-    source         => 'https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml',
-    require        => Exec['test conf present']
+    ensure  => present,
+    source  => 'https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml',
+    require => Exec['test conf present']
   }
 
   exec { 'test conf present':


### PR DESCRIPTION
The service was managed properly on Amazon Linux 201* instances, the default provider that Puppet chose was not able to ensure that service is running.

I also changed sysmonconfig-export.xml to use the remote_file resource since we were running into problems with the regular file resource with a masterless Puppet apply. I also removed the checksum check since the remote file is being automatically updated (last update 2020-01-16) and the checksum didn't match, causing failures. 