### PR TITLE
Use the default keyserver.

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -35,7 +35,6 @@ class threatstack::apt (
     repos    => $repos,
     key      => {
       'id'     => $key,
-      'server' => 'hkps.pool.sks-keyservers.net'
-      }
+    }
   }
 }


### PR DESCRIPTION
Specifying the keyserver as the module previously does leads to
  intermittent failure when puppeting, when the keyserver is not
  available.
The apt::key resource defaults to using the Ubuntu keyserver, and that
  is much more reliable.
  https://github.com/puppetlabs/puppetlabs-apt/blob/master/manifests/params.pp#L20