### PR TITLE
Fix multiple rulesets

### DIFF
--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -18,17 +18,15 @@
 # Copyright 2020 Threat Stack, Inc.
 #
 class threatstack::configure {
-  $rulesets       = $::threatstack::rulesets
-  $ruleset_args   = $rulesets.map | $rule | {
-        "--ruleset='${rule}'"
-      }
+  $ruleset_args   = "--ruleset=${join($::threatstack::rulesets, ',')}"
+
   if $::threatstack::extra_args {
     $extra_args = $::threatstack::extra_args.map | $arg | {
           "--${arg.keys[0]}=${arg.values[0]}"
         }
-    $full_setup_args = "${join($ruleset_args, ' ')} ${join($extra_args, ' ')}"
+    $full_setup_args = "${ruleset_args} ${join($extra_args, ' ')}"
   } else {
-    $full_setup_args = "${join($ruleset_args, ' ')}"
+    $full_setup_args = $ruleset_args
   }
 
   $cloudsight_bin = $::threatstack::cloudsight_bin

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -18,7 +18,7 @@
 # Copyright 2020 Threat Stack, Inc.
 #
 class threatstack::configure {
-  $ruleset_args   = "--ruleset=${join($::threatstack::rulesets, ',')}"
+  $ruleset_args   = "--ruleset='${join($::threatstack::rulesets, ',')}'"
 
   if $::threatstack::extra_args {
     $extra_args = $::threatstack::extra_args.map | $arg | {

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -10,7 +10,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -19,7 +19,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -28,7 +28,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -37,7 +37,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -46,7 +46,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -55,7 +55,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -64,7 +64,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 
@@ -73,7 +73,7 @@ describe 'threatstack::configure' do
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
-      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset' --ruleset='Service Ruleset'"
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
 


### PR DESCRIPTION
The agent configuration exec supports only a single --ruleset flag with a comma separated list of rules to be applied. For example:
`--ruleset='TechniqueMatrix,Server Specific Rulesets'`

This PR addresses the issue