### PR TITLE
add support for newer distro versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 We'll track changes here starting with details about the 2.0 release and reference to earlier releases.
 
+## 2.0.10
+### Added
+- updated README with support for
+  - Debian 10
+  - Ubuntu 20.04
+  - CentOS/RedHat 8
+- updated tests for newer distros
+- added optional parameter to enable/disable yum repo on rhel
+
 ## 2.0.9
 ### Fixed
 - merged PR simplifying ruleset args

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Parameters
 * `threatstack::package_version` [optional string] - version of the `threatstack-agent` package to install (Default: `installed`)
 * `threatstack::repo_class` [optional string] - name of puppet class that configures the threatstack package repo (Default: either `threatstack::apt` or `threatstack::yum`, set in `threatstack::params` based on operating system)
 * `threatstack::repo_url` [optional string] - url used by threatstack package repo (Default: defined in `threatstack::params` for Debian and RedHat operating system families.)
+* `threatstack::repo_enabled` [optional string] - enable/disable the threatstack repo (Default: defined in `threatstack::params` for RedHat operating system families.)
 * `threatstack::windows_download_url` [optional string] - url used to download Threatstack Agent MSI on Windows 
 * `threatstack::windows_install_options` [optional array] - Windows MSI install options
 * `threatstack::windows_ts_package` [optional string] - Windows MSI package name

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,6 @@
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.require_version ">= 1.5.0"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "centos/7"
+  config.vm.provision "shell", path: "./config.sh"
+end

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -1,4 +1,5 @@
 ---
 threatstack::params:
     repo_class: '::threatstack::yum'
+    repo_enabled: '1'
     gpg_key: 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,10 @@
 #   Manage agent package version.
 #   type: string
 #
+# [*repo_enabled*]
+#   Enable/disable yum repo
+#   type: string
+#
 # [*repo_url*]
 #   URL of installation repo.  Useful to change if managing own repository.  See
 #   also `gpg_key`.
@@ -119,6 +123,7 @@ class threatstack (
   $extra_args              = $::threatstack::params::extra_args,
   $agent_config_args       = undef,
   $repo_class              = $::threatstack::params::repo_class,
+  $repo_enabled            = $::threatstack::params::repo_enabled,
   $repo_url                = $::threatstack::params::repo_url,
   $gpg_key                 = $::threatstack::params::gpg_key,
   $rulesets                = $::threatstack::params::rulesets,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,7 @@ class threatstack::params {
     }
     'RedHat': {
       $repo_class       = '::threatstack::yum'
+      $repo_enabled     = '1'
       $gpg_key          = 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file     = '/etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       $gpg_key_file_uri = "file://${gpg_key_file}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,6 +86,7 @@ class threatstack::params {
     'Debian': {
       $repo_class         = '::threatstack::apt'
       $repo_url           = 'https://pkg.threatstack.com/v2/Ubuntu'
+      $repo_enabled       = undef
       $repo_gpg_id        = 'ACCC2B02EA3A2409557B0AB991BB3B3C6EE04BD4'
       $release            = $facts['os']['distro']['codename']
       $repos              = 'main'

--- a/manifests/yum.pp
+++ b/manifests/yum.pp
@@ -39,7 +39,7 @@ class threatstack::yum inherits ::threatstack::params {
 
   yumrepo { 'threatstack':
     descr    => 'Threat Stack Package Repository',
-    enabled  => 1,
+    enabled  => $::threatstack::repo_enabled,
     baseurl  => $::threatstack::repo_url,
     gpgcheck => 1,
     gpgkey   => $::threatstack::gpg_key_file_uri,

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,13 @@
   "source": "https://github.com/threatstack/threatstack-puppet",
   "issues_url": "https://github.com/threatstack/threatstack-puppet/issues",
   "tags": ["threatstack"],
+  "data_provider": "hiera",
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.5.0 < 7.0.0"
+    }
+  ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.2" },
     {"name": "puppetlabs/apt", "version_requirement": ">= 6.2.1"},

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "threatstack-threatstack",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "author": "Threat Stack",
   "license": "Apache-2.0",
   "summary": "Installs the Threat Stack agent",
@@ -17,22 +17,22 @@
   "operatingsystem_support": [
     {
     "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "7.0", "7.5" ]
+    "operatingsystemrelease":[ "7.0", "7.5", "8.0" ]
     },
     {
     "operatingsystem":"CentOS",
-    "operatingsystemrelease":[ "7.0", "7.5" ]
+    "operatingsystemrelease":[ "7.0", "7.5", "8.0" ]
     },
     {
     "operatingsystem":"Amazon"
     },
     {
     "operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [ "18.04", "16.04" ]
+    "operatingsystemrelease": [ "20.04", "18.04", "16.04" ]
     },
     {
     "operatingsystem": "Debian",
-    "operatingsystemrelease": [ "9", "8" ]
+    "operatingsystemrelease": [ "10", "9", "8" ]
     },
     {
     "operatingsystem": "Windows",

--- a/spec/classes/apt_spec.rb
+++ b/spec/classes/apt_spec.rb
@@ -22,6 +22,22 @@ describe 'threatstack::apt' do
       }
   end
 
+  context 'on Debian 10' do
+    let(:facts) { {'operatingsystem' => 'Debian', 'osfamily' => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '10.4', 'major' => '10', 'minor' => '4'}, 'distro' => {'codename' => 'buster'}, 'family' => 'Debian'} } }
+    let(:params) { { 'location' => REPO_URL, 'release' => 'buster', 'repos' => REPO_TYPE, 'key' => GPG_KEY_ID} }
+    it {
+        is_expected.to contain_apt__source('threatstack').with(ensure: 'present', location: REPO_URL, release: 'buster', repos: REPO_TYPE)
+      }
+  end
+
+  context 'on Ubuntu 20.04' do
+    let(:facts) { {'osfamily' => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '20.04', 'major' => '20.04'}, 'distro' => {'codename' => 'focal'}, 'family' => 'Debian'} }}
+    let(:params) { { 'location' => REPO_URL, 'release' => 'focal', 'repos' => REPO_TYPE, 'key' => GPG_KEY_ID} }
+    it {
+        is_expected.to contain_apt__source('threatstack').with(ensure: 'present', location: REPO_URL, release: 'focal', repos: REPO_TYPE)
+      }
+  end
+
   context 'on Ubuntu 18.04' do
     let(:facts) { {'osfamily' => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '18.04', 'major' => '18.04'}, 'distro' => {'codename' => 'bionic'}, 'family' => 'Debian'} }}
     let(:params) { { 'location' => REPO_URL, 'release' => 'bionic', 'repos' => REPO_TYPE, 'key' => GPG_KEY_ID} }

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -23,6 +23,24 @@ describe 'threatstack::configure' do
     )}
   end
 
+  context 'on Debian 10' do
+    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '10.4', 'major' => '10', 'minor' => '4'}, 'distro' => {'codename' => 'buster'}, 'family' => 'Debian'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+
+    it { should contain_exec('threatstack-agent-setup').with(
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
+    )}
+  end
+
+  context 'on Ubuntu 20.04' do
+    let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '20.04', 'major' => '20'}, 'distro' => {'codename' => 'focal'}, 'family' => 'Debian'} }}
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+
+    it { should contain_exec('threatstack-agent-setup').with(
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
+    )}
+  end
+
   context 'on Ubuntu 18.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '18.04', 'major' => '18.04'}, 'distro' => {'codename' => 'bionic'}, 'family' => 'Debian'} }}
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
@@ -41,8 +59,26 @@ describe 'threatstack::configure' do
     )}
   end
 
-  context 'on Redhat' do
+  context 'on Redhat 8' do
+      let(:facts) {  { :operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '8.0', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+
+    it { should contain_exec('threatstack-agent-setup').with(
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
+    )}
+  end
+
+  context 'on Redhat 7' do
       let(:facts) {  { :operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '7.0', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+
+    it { should contain_exec('threatstack-agent-setup').with(
+      :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
+    )}
+  end
+
+  context 'on CentOS 8' do
+    let(:facts) { { :operatingsystem => 'CentOS', :osfamily => 'RedHat',:operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
 
     it { should contain_exec('threatstack-agent-setup').with(

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -7,7 +7,7 @@ describe 'threatstack::configure' do
 
   context 'on Debian 8' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '8.11', 'major' => '8', 'minor' => '11'}, 'distro' => {'codename' => 'jessie'}, 'family' => 'Debian'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -16,7 +16,7 @@ describe 'threatstack::configure' do
 
   context 'on Debian 9' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '9.1', 'major' => '9', 'minor' => '1'}, 'distro' => {'codename' => 'stretch'}, 'family' => 'Debian'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -25,7 +25,7 @@ describe 'threatstack::configure' do
 
   context 'on Debian 10' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '10.4', 'major' => '10', 'minor' => '4'}, 'distro' => {'codename' => 'buster'}, 'family' => 'Debian'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -34,7 +34,7 @@ describe 'threatstack::configure' do
 
   context 'on Ubuntu 20.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '20.04', 'major' => '20'}, 'distro' => {'codename' => 'focal'}, 'family' => 'Debian'} }}
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -43,7 +43,7 @@ describe 'threatstack::configure' do
 
   context 'on Ubuntu 18.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '18.04', 'major' => '18.04'}, 'distro' => {'codename' => 'bionic'}, 'family' => 'Debian'} }}
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -52,7 +52,7 @@ describe 'threatstack::configure' do
 
   context 'on Ubuntu 16.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '16.04', 'major' => '16.04'}, 'distro' => {'codename' => 'xenial'}, 'family' => 'Debian'} }}
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -61,7 +61,7 @@ describe 'threatstack::configure' do
 
   context 'on Redhat 8' do
       let(:facts) {  { :operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '8.0', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -70,7 +70,7 @@ describe 'threatstack::configure' do
 
   context 'on Redhat 7' do
       let(:facts) {  { :operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '7.0', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -79,7 +79,7 @@ describe 'threatstack::configure' do
 
   context 'on CentOS 8' do
     let(:facts) { { :operatingsystem => 'CentOS', :osfamily => 'RedHat',:operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -88,7 +88,7 @@ describe 'threatstack::configure' do
 
   context 'on CentOS 7' do
     let(:facts) { { :operatingsystem => 'CentOS', :osfamily => 'RedHat',:operatingsystemrelease => '7.6.1810', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -97,7 +97,7 @@ describe 'threatstack::configure' do
 
   context 'on Amazon Linux 2' do
     let(:facts) {  { :operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2', 'operatingsystemmajrelease' => '2', 'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -106,11 +106,10 @@ describe 'threatstack::configure' do
 
   context 'on Amazon Linux 1' do
     let(:facts) {  {:operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2018', 'operatingsystemmajrelease' => '2018', 'os' => {  'release' => { 'major' => '2018'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
     )}
   end
-
 end

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -7,7 +7,7 @@ describe 'threatstack::configure' do
 
   context 'on Debian 8' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '8.11', 'major' => '8', 'minor' => '11'}, 'distro' => {'codename' => 'jessie'}, 'family' => 'Debian'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => true}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -16,7 +16,7 @@ describe 'threatstack::configure' do
 
   context 'on Debian 9' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '9.1', 'major' => '9', 'minor' => '1'}, 'distro' => {'codename' => 'stretch'}, 'family' => 'Debian'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => true}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -25,7 +25,7 @@ describe 'threatstack::configure' do
 
   context 'on Debian 10' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '10.4', 'major' => '10', 'minor' => '4'}, 'distro' => {'codename' => 'buster'}, 'family' => 'Debian'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => true}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -34,7 +34,7 @@ describe 'threatstack::configure' do
 
   context 'on Ubuntu 20.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '20.04', 'major' => '20'}, 'distro' => {'codename' => 'focal'}, 'family' => 'Debian'} }}
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => true}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -43,7 +43,7 @@ describe 'threatstack::configure' do
 
   context 'on Ubuntu 18.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '18.04', 'major' => '18.04'}, 'distro' => {'codename' => 'bionic'}, 'family' => 'Debian'} }}
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => true}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -52,7 +52,7 @@ describe 'threatstack::configure' do
 
   context 'on Ubuntu 16.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '16.04', 'major' => '16.04'}, 'distro' => {'codename' => 'xenial'}, 'family' => 'Debian'} }}
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => true" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => true}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -61,7 +61,7 @@ describe 'threatstack::configure' do
 
   context 'on Redhat 8' do
       let(:facts) {  { :operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '8.0', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => '1'}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -70,7 +70,7 @@ describe 'threatstack::configure' do
 
   context 'on Redhat 7' do
       let(:facts) {  { :operatingsystem => 'RedHat', :osfamily => 'RedHat', :operatingsystemrelease => '7.0', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => '1'}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -79,7 +79,7 @@ describe 'threatstack::configure' do
 
   context 'on CentOS 8' do
     let(:facts) { { :operatingsystem => 'CentOS', :osfamily => 'RedHat',:operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => '1'}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -88,7 +88,7 @@ describe 'threatstack::configure' do
 
   context 'on CentOS 7' do
     let(:facts) { { :operatingsystem => 'CentOS', :osfamily => 'RedHat',:operatingsystemrelease => '7.6.1810', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => '1'}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -97,7 +97,7 @@ describe 'threatstack::configure' do
 
   context 'on Amazon Linux 2' do
     let(:facts) {  { :operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2', 'operatingsystemmajrelease' => '2', 'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => '1'}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"
@@ -106,7 +106,7 @@ describe 'threatstack::configure' do
 
   context 'on Amazon Linux 1' do
     let(:facts) {  {:operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2018', 'operatingsystemmajrelease' => '2018', 'os' => {  'release' => { 'major' => '2018'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}]}, repo_enabled => '1'" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', ts_hostname => '#{ts_hostname}', rulesets => ['Default Ruleset', 'Service Ruleset'], agent_config_args => [{'log.level' => 'debug'}], repo_enabled => '1'}" }
 
     it { should contain_exec('threatstack-agent-setup').with(
       :command => "/usr/bin/tsagent setup --deploy-key='#{deploy_key}' --hostname='#{ts_hostname}' --ruleset='Default Ruleset,Service Ruleset'"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,6 +22,24 @@ describe 'threatstack' do
     it { should contain_class('threatstack::configure') }
   end
 
+  context 'on Debian 10' do
+    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '10.4', 'major' => '10', 'minor' => '4'}, 'distro' => {'codename' => 'buster'}, 'family' => 'Debian'} } }
+    let(:params) { { :deploy_key => "#{deploy_key}" } }
+
+    it 'should compile' do should create_class('threatstack') end
+    it { should contain_class('threatstack::package') }
+    it { should contain_class('threatstack::configure') }
+  end
+
+  context 'on Ubuntu 20.04' do
+    let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '20.04', 'major' => '20.04'}, 'distro' => {'codename' => 'focal'}, 'family' => 'Debian'} }}
+    let(:params) { { :deploy_key => "#{deploy_key}" } }
+
+    it 'should compile' do should create_class('threatstack') end
+    it { should contain_class('threatstack::package') }
+    it { should contain_class('threatstack::configure') }
+  end
+
   context 'on Ubuntu 18.04' do
     let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '18.04', 'major' => '18.04'}, 'distro' => {'codename' => 'bionic'}, 'family' => 'Debian'} }}
     let(:params) { { :deploy_key => "#{deploy_key}" } }
@@ -40,24 +58,40 @@ describe 'threatstack' do
     it { should contain_class('threatstack::configure') }
   end
 
-  context 'on RedHat' do
+  context 'on RedHat 8' do
+    let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'full' => '8.2.2004', 'major' => '8', 'minor' => '2'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
+    let(:params) { { :deploy_key => "#{deploy_key}" } }
+
+    it 'should compile' do should create_class('threatstack') end
+    it { should contain_class('threatstack::package') }
+    it { should contain_class('threatstack::configure') }
+  end
+
+  context 'on RedHat 7' do
     let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemrelease => '7.5', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'full' => '7.5', 'major' => '7', 'minor' => '5'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
     let(:params) { { :deploy_key => "#{deploy_key}" } }
 
     it 'should compile' do should create_class('threatstack') end
     it { should contain_class('threatstack::package') }
     it { should contain_class('threatstack::configure') }
-
   end
 
-  context 'on CentOS' do
+  context 'on CentOS 8' do
+    let(:facts) {  { :osfamily => 'CentOS', :operatingsystem => 'CentOS', :operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'full' => '8.2.2004', 'major' => '8', 'minor' => '2'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
+    let(:params) { { :deploy_key => "#{deploy_key}" } }
+
+    it 'should compile' do should create_class('threatstack') end
+    it { should contain_class('threatstack::package') }
+    it { should contain_class('threatstack::configure') }
+  end
+
+  context 'on CentOS 7' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '7.4.1708', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'full' => '7.4.1708', 'major' => '7', 'minor' => '4'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
     let(:params) { { :deploy_key => "#{deploy_key}" } }
 
     it 'should compile' do should create_class('threatstack') end
     it { should contain_class('threatstack::package') }
     it { should contain_class('threatstack::configure') }
-
   end
 
   context 'on Amazon Linux 2' do
@@ -67,9 +101,7 @@ describe 'threatstack' do
     it 'should compile' do should create_class('threatstack') end
     it { should contain_class('threatstack::package') }
     it { should contain_class('threatstack::configure') }
-
   end
-
 
   context 'on Amazon Linux 1' do
     let(:facts) { { :operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2018', 'operatingsystemmajrelease' => '2018', 'os' => { 'name' => 'Amazon', 'family' => 'RedHat', 'release' => { 'major' => '2018'}} } }
@@ -78,8 +110,5 @@ describe 'threatstack' do
     it 'should compile' do should create_class('threatstack') end
     it { should contain_class('threatstack::package') }
     it { should contain_class('threatstack::configure') }
-
   end
-
-
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,7 +77,7 @@ describe 'threatstack' do
   end
 
   context 'on CentOS 8' do
-    let(:facts) {  { :osfamily => 'CentOS', :operatingsystem => 'CentOS', :operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'full' => '8.2.2004', 'major' => '8', 'minor' => '2'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
+    let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'CentOS', :operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'full' => '8.2.2004', 'major' => '8', 'minor' => '2'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
     let(:params) { { :deploy_key => "#{deploy_key}" } }
 
     it 'should compile' do should create_class('threatstack') end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -3,7 +3,16 @@ require 'spec_helper'
 describe 'threatstack::package' do
   deploy_key = ENV['TS_DEPLOY_KEY'] ? ENV['TS_DEPLOY_KEY'] : "xKkRzesqg"
 
-  context 'on RedHat' do
+  context 'on RedHat 8' do
+      let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'RedHat',  :operatingsystemrelease => '8.2', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'full' => '8.2', 'major' => '8', 'minor' => '2'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+
+    context 'package' do
+      it { should contain_package('threatstack-agent').with_ensure('installed') }
+    end
+  end
+
+  context 'on RedHat 7' do
       let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'RedHat',  :operatingsystemrelease => '7.5', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'full' => '7.5', 'major' => '7', 'minor' => '5'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
 
@@ -12,8 +21,17 @@ describe 'threatstack::package' do
     end
   end
 
+  context 'on CentOS 8' do
+    let(:facts) { {:operatingsystem => 'CentOS', :osfamily => 'RedHat', :operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+
+    context 'package' do
+      it { should contain_package('threatstack-agent').with_ensure('installed') }
+    end
+  end
+
   context 'on CentOS 7' do
-    let(:facts) { {:operatingsystem => 'CentOs', :osfamily => 'RedHat', :operatingsystemrelease => '7.6.1810', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
+    let(:facts) { {:operatingsystem => 'CentOS', :osfamily => 'RedHat', :operatingsystemrelease => '7.6.1810', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
 
     context 'package' do
@@ -50,6 +68,24 @@ describe 'threatstack::package' do
 
   context 'on Debian 9' do
     let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '9.1', 'major' => '9', 'minor' => '1'}, 'distro' => {'codename' => 'stretch'}, 'family' => 'Debian'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK', repo_class => '::threatstack::apt' }" }
+
+    context 'package' do
+      it { should contain_package('threatstack-agent').with_ensure('installed') }
+    end
+  end
+
+  context 'on Debian 10' do
+    let(:facts) { {:operatingsystem => 'Debian', :osfamily => 'Debian', 'os' => { 'name' => 'Debian', 'release' => {'full' => '10.4', 'major' => '10', 'minor' => '4'}, 'distro' => {'codename' => 'buster'}, 'family' => 'Debian'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK', repo_class => '::threatstack::apt' }" }
+
+    context 'package' do
+      it { should contain_package('threatstack-agent').with_ensure('installed') }
+    end
+  end
+
+  context 'on Ubuntu 20.04' do
+    let(:facts) { {:osfamily => 'Debian', 'os' => { 'name' => 'Ubuntu', 'release' => {'full' => '20.04', 'major' => '20.04'}, 'distro' => {'codename' => 'focal'}, 'family' => 'Debian'} }}
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK', repo_class => '::threatstack::apt' }" }
 
     context 'package' do

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -5,7 +5,7 @@ describe 'threatstack::package' do
 
   context 'on RedHat 8' do
       let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'RedHat',  :operatingsystemrelease => '8.2', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'full' => '8.2', 'major' => '8', 'minor' => '2'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum', repo_enabled => '1' }" }
 
     context 'package' do
       it { should contain_package('threatstack-agent').with_ensure('installed') }
@@ -14,7 +14,7 @@ describe 'threatstack::package' do
 
   context 'on RedHat 7' do
       let(:facts) {  { :osfamily => 'RedHat', :operatingsystem => 'RedHat',  :operatingsystemrelease => '7.5', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'full' => '7.5', 'major' => '7', 'minor' => '5'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum', repo_enabled => '1' }" }
 
     context 'package' do
       it { should contain_package('threatstack-agent').with_ensure('installed') }
@@ -23,7 +23,7 @@ describe 'threatstack::package' do
 
   context 'on CentOS 8' do
     let(:facts) { {:operatingsystem => 'CentOS', :osfamily => 'RedHat', :operatingsystemrelease => '8.2.2004', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum', repo_enabled => '1' }" }
 
     context 'package' do
       it { should contain_package('threatstack-agent').with_ensure('installed') }
@@ -32,7 +32,7 @@ describe 'threatstack::package' do
 
   context 'on CentOS 7' do
     let(:facts) { {:operatingsystem => 'CentOS', :osfamily => 'RedHat', :operatingsystemrelease => '7.6.1810', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum', repo_enabled => '1' }" }
 
     context 'package' do
       it { should contain_package('threatstack-agent').with_ensure('installed') }
@@ -41,7 +41,7 @@ describe 'threatstack::package' do
 
   context 'on Amazon Linux 2' do
       let(:facts) {  { :operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2.0', 'operatingsystemmajrelease' => '2', 'os' => {  'release' => { 'major' => '2'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum', repo_enabled => '1' }" }
 
     context 'package' do
       it { should contain_package('threatstack-agent').with_ensure('installed') }
@@ -50,7 +50,7 @@ describe 'threatstack::package' do
 
   context 'on Amazon Linux 1' do
     let(:facts) {  {:operatingsystem => 'Amazon', :osfamily => 'RedHat', :operatingsystemrelease => '2018', 'operatingsystemmajrelease' => '1', 'os' => {  'release' => { 'major' => '1'}, 'name' => 'Amazon', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_class => '::threatstack::yum', repo_enabled => '1' }" }
 
     context 'package' do
       it { should contain_package('threatstack-agent').with_ensure('installed') }

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -13,7 +13,7 @@ describe 'threatstack::yum' do
       it { should contain_yumrepo('threatstack').with(
         :descr     => 'Threat Stack Package Repository',
         :enabled   => 1,
-        :baseurl   => 'https://pkg.threatstack.com/v2/EL/7',
+        :baseurl   => 'https://pkg.threatstack.com/v2/EL/8',
         :gpgcheck  => 1,
         :gpgkey    => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       ) }
@@ -43,7 +43,7 @@ describe 'threatstack::yum' do
       it { should contain_yumrepo('threatstack').with(
         :descr     => 'Threat Stack Package Repository',
         :enabled   => 1,
-        :baseurl   => 'https://pkg.threatstack.com/v2/EL/7',
+        :baseurl   => 'https://pkg.threatstack.com/v2/EL/8',
         :gpgcheck  => 1,
         :gpgkey    => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
       ) }

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -7,7 +7,7 @@ describe 'threatstack::yum' do
 
   context 'on RedHat 8' do
     let(:facts) {  { :operatingsystem => 'RedHat', 'operatingsystemrelease' => '8.2.2004', :osfamily => 'RedHat', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_enabled => '1'}" }
 
     context 'default' do
       it { should contain_yumrepo('threatstack').with(
@@ -37,7 +37,7 @@ describe 'threatstack::yum' do
 
   context 'on CentOS 8' do
     let(:facts) { {:operatingsystem => 'CentOS', 'operatingsystemrelease' => '8.2.2004', :osfamily => 'RedHat', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
-    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK', repo_enabled => '1' }" }
 
     context 'default' do
       it { should contain_yumrepo('threatstack').with(

--- a/spec/classes/yum_spec.rb
+++ b/spec/classes/yum_spec.rb
@@ -5,7 +5,22 @@ describe 'threatstack::yum' do
   deploy_key = ENV['TS_DEPLOY_KEY'] ? ENV['TS_DEPLOY_KEY'] : "xKkRzesqg"
   gpgkey = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
 
-  context 'on RedHat' do
+  context 'on RedHat 8' do
+    let(:facts) {  { :operatingsystem => 'RedHat', 'operatingsystemrelease' => '8.2.2004', :osfamily => 'RedHat', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
+
+    context 'default' do
+      it { should contain_yumrepo('threatstack').with(
+        :descr     => 'Threat Stack Package Repository',
+        :enabled   => 1,
+        :baseurl   => 'https://pkg.threatstack.com/v2/EL/7',
+        :gpgcheck  => 1,
+        :gpgkey    => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
+      ) }
+    end
+  end
+
+  context 'on RedHat 7' do
     let(:facts) {  { :operatingsystem => 'RedHat', 'operatingsystemrelease' => '7.6.1810', :osfamily => 'RedHat', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'RedHat', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
 
@@ -20,7 +35,22 @@ describe 'threatstack::yum' do
     end
   end
 
-  context 'on CentOS' do
+  context 'on CentOS 8' do
+    let(:facts) { {:operatingsystem => 'CentOS', 'operatingsystemrelease' => '8.2.2004', :osfamily => 'RedHat', 'operatingsystemmajrelease' => '8', 'os' => { 'release' => { 'major' => '8'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
+    let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
+
+    context 'default' do
+      it { should contain_yumrepo('threatstack').with(
+        :descr     => 'Threat Stack Package Repository',
+        :enabled   => 1,
+        :baseurl   => 'https://pkg.threatstack.com/v2/EL/7',
+        :gpgcheck  => 1,
+        :gpgkey    => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-THREATSTACK'
+      ) }
+    end
+  end
+
+  context 'on CentOS 7' do
     let(:facts) { {:operatingsystem => 'CentOS', 'operatingsystemrelease' => '7.6.1810', :osfamily => 'RedHat', 'operatingsystemmajrelease' => '7', 'os' => { 'release' => { 'major' => '7'}, 'name' => 'CentOS', 'family' => 'RedHat'} } }
     let(:pre_condition) { "class { 'threatstack': deploy_key => '#{deploy_key}', gpg_key => 'https://app.threatstack.com/RPM-GPG-KEY-THREATSTACK' }" }
 


### PR DESCRIPTION
- added support for:
  - debian 10
  - ubuntu 20.04
  - centos/redhat 8
- updated spec tests to reflect these changes
- updated readme/changelog/metadata
- tested a bit on puppet 6 to check backwards compatibility (seems fine)