### PR TITLE
Update package.pp

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -26,7 +26,6 @@ class threatstack::package {
     } else {
       class {'auditd':
         enable     => false,
-        at_boot    => false,
         plugin_dir => '/etc/audisp/plugins.d'
       }
     $required = [ Class[$::threatstack::repo_class], Class['auditd'] ]


### PR DESCRIPTION
Defining the threatstack::disable_auditd parameter disables the hosts audit sub-system by setting the kernel parameter audit=0. This prevents processes from being visible to audit and the agent's capability to report those processes. 

Default is 'true' on RHEL-like OSes.